### PR TITLE
确保混输能输入含大写字母的单词；解决输入大写字母时无法用数字键选词。

### DIFF
--- a/easy_en.schema.yaml
+++ b/easy_en.schema.yaml
@@ -54,3 +54,5 @@ punctuator:
 
 recognizer:
   import_preset: default
+  patterns:
+    uppercase: ''

--- a/easy_en.yaml
+++ b/easy_en.yaml
@@ -1,11 +1,16 @@
 # encoding: utf-8
 ---
 patch:
-  "schema/dependencies/@next": easy_en
-  "engine/translators/@next": table_translator@easy_en
+  schema/dependencies/+:
+    - easy_en
+  engine/translators/+:
+    - table_translator@easy_en
   easy_en:
     dictionary: easy_en
     spelling_hints: 9
     enable_completion: true
     enable_sentence: true
     initial_quality: -1
+  recognizer/patterns/uppercase: ''
+  speller/alphabet:
+    __include: easy_en.schema:/speller/alphabet

--- a/easy_en.yaml
+++ b/easy_en.yaml
@@ -1,10 +1,8 @@
 # encoding: utf-8
 ---
 patch:
-  schema/dependencies/+:
-    - easy_en
-  engine/translators/+:
-    - table_translator@easy_en
+  schema/dependencies/@next: easy_en
+  engine/translators/@next: table_translator@easy_en
   easy_en:
     dictionary: easy_en
     spelling_hints: 9


### PR DESCRIPTION
## 确保混输能输入含大写字母的单词

混输的主方案一般不会定义大写字母为编码字符，将 easy_en.schema 的定义写入补丁可确保定义。

## 解决输入大写字母时无法用数字键选词

default.yaml 中的 `recognizer/pattern/uppercase` 会匹配到含大写字母和数字的输入串，将该 pattern 置空可解决此问题。

## 其它

补丁中不建议使用 `@` 系列写法，改为官方建议的 `+` 写法。已知的问题是在同节点下使用多个 `@` 时，索引都是以源文件的列表为基础，故多个 `@next` 只会添加一项，只有最后一个定义生效。单就 easy_en.yaml 这一组补丁而言，没有这个问题。