### PR TITLE
Disable word creation

### DIFF
--- a/easy_en.schema.yaml
+++ b/easy_en.schema.yaml
@@ -5,7 +5,7 @@
 schema:
   schema_id: easy_en
   name: Easy English
-  version: "0.3"
+  version: "0.4"
   author:
     - Patrick <ipatrickmac@gmail.com>
   description:
@@ -45,6 +45,8 @@ speller:
 translator:
   dictionary: easy_en
   spelling_hints: 9
+  enable_encoder: false
+  enable_sentence: false
   comment_format:
     - xform/^.+$//
 


### PR DESCRIPTION
現在會自動造詞，即隨便亂打一些不存在的單詞，也會在候選中出現。這可能是因為輸入法把幾個縮寫詞連起來了，當成了一個新的詞。禁用自動造詞功能後就不會出現這種情況了。